### PR TITLE
feat: Try to create container once on upload

### DIFF
--- a/lib/api/azure/container.ex
+++ b/lib/api/azure/container.ex
@@ -7,7 +7,7 @@ defmodule FileStorageApi.API.Azure.Container do
   alias FileStorageApi.{Container, File}
 
   @impl true
-  def create(container_name, _) do
+  def create(container_name, _opts \\ %{}) do
     AzureContainer.create_container(container(container_name))
   end
 

--- a/lib/api/azure/file.ex
+++ b/lib/api/azure/file.ex
@@ -11,6 +11,8 @@ defmodule FileStorageApi.API.Azure.File do
       {:ok, %{request_url: _request_url}} ->
         {:ok, blob_name || Path.basename(filename)}
 
+      {:error, %{error_code: "ContainerNotFound"}} ->
+        {:error, :container_not_found}
       error ->
         error
     end

--- a/lib/api/s3/container.ex
+++ b/lib/api/s3/container.ex
@@ -7,7 +7,7 @@ defmodule FileStorageApi.API.S3.Container do
   alias FileStorageApi.{Container, File}
 
   @impl true
-  def create(container_name, opts) do
+  def create(container_name, opts \\ %{}) do
     result =
       container_name
       |> S3.put_bucket(region())

--- a/lib/api/s3/file.ex
+++ b/lib/api/s3/file.ex
@@ -16,8 +16,8 @@ defmodule FileStorageApi.API.S3.File do
       {:ok, %{status_code: 200}} ->
         {:ok, object}
 
-      error ->
-        error
+      {:error, error} ->
+        handle_error(error)
     end
   end
 
@@ -44,4 +44,16 @@ defmodule FileStorageApi.API.S3.File do
   end
 
   def last_modified(_), do: {:error, :incorrect_format}
+
+  defp handle_error({_, _, %{status_code: 404, body: body}} = error) do
+    if String.contains?(body, "<Code>NoSuchBucket</Code>") do
+      {:error, :container_not_found}
+    else
+      {:error, error}
+    end
+  end
+
+  defp handle_error(error) do
+    {:error, error}
+  end
 end

--- a/lib/file.ex
+++ b/lib/file.ex
@@ -28,7 +28,7 @@ defmodule FileStorageApi.File do
     case {api_module(File).upload(container_name, filename, blob_name), force_container} do
       {{:ok, file}, _} -> {:ok, file}
       {{:error, :container_not_found}, true} ->
-        api_module(Container).create(container_name)
+        api_module(Container).create(container_name, %{})
         upload(container_name, filename, blob_name, Keyword.put(opts, :force_container, false))
 
       {{:error, error}, _} -> {:file_upload_error, error}

--- a/test/api/file_test.exs
+++ b/test/api/file_test.exs
@@ -1,9 +1,9 @@
 defmodule FileStorageApi.FileTest do
   use ExUnit.Case
 
-  alias FileStorageApi.File
-  alias FileStorageApi.API.Mock.File, as: FileMock
   alias FileStorageApi.API.Mock.Container, as: ContainerMock
+  alias FileStorageApi.API.Mock.File, as: FileMock
+  alias FileStorageApi.File
 
   import Mox
 

--- a/test/api/file_test.exs
+++ b/test/api/file_test.exs
@@ -2,6 +2,8 @@ defmodule FileStorageApi.FileTest do
   use ExUnit.Case
 
   alias FileStorageApi.File
+  alias FileStorageApi.API.Mock.File, as: FileMock
+  alias FileStorageApi.API.Mock.Container, as: ContainerMock
 
   import Mox
 
@@ -12,15 +14,55 @@ defmodule FileStorageApi.FileTest do
   end
 
   test "able to upload a file" do
-    expect(FileStorageApi.API.Mock.File, :upload, fn "block-store-container", "testfile", _blob_name ->
+    expect(FileMock, :upload, fn "block-store-container", "testfile", _blob_name ->
       {:ok, %{}}
     end)
 
     assert {:ok, %{}} == File.upload("block-store-container", "testfile", "testfile")
   end
 
+  test "not creating a container if not forcing on a failed upload" do
+    FileMock
+    |> expect(:upload, 1, fn "block-store-container", "testfile", _blob_name ->
+      {:error, "Some Error"}
+    end)
+
+    assert {:file_upload_error, "Some Error"} == File.upload("block-store-container", "testfile", "testfile", force_container: false)
+  end
+
+  test "creating a container once, if file upload fails because of it" do
+    FileMock
+    |> expect(:upload, 1, fn "block-store-container", "testfile", _blob_name ->
+      {:error, :container_not_found}
+    end)
+    |> expect(:upload, 1, fn "block-store-container", "testfile", _blob_name ->
+      {:ok, "file uploaded!"}
+    end)
+
+    ContainerMock
+    |> expect(:create, 1, fn "block-store-container", _ ->
+      {:ok, %{}}
+    end)
+
+    assert {:ok, "file uploaded!"} == File.upload("block-store-container", "testfile", "testfile")
+  end
+
+  test "returning the error if creating container didn't help" do
+    FileMock
+    |> expect(:upload, 2, fn "block-store-container", "testfile", _blob_name ->
+      {:error, :container_not_found}
+    end)
+
+    ContainerMock
+    |> expect(:create, 1, fn "block-store-container", _ ->
+      {:ok, %{}}
+    end)
+
+    assert {:file_upload_error, :container_not_found} == File.upload("block-store-container", "testfile", "testfile")
+  end
+
   test "able to request public url without setting expire" do
-    expect(FileStorageApi.API.Mock.File, :public_url, fn container_name, filename, start_time, expire_time ->
+    expect(FileMock, :public_url, fn container_name, filename, start_time, expire_time ->
       start_time_str = Timex.format!(start_time, "{YYYY}-{0M}-{0D}T{0h24}:{0m}:{0s}Z")
       expire_time_str = Timex.format!(expire_time, "{YYYY}-{0M}-{0D}T{0h24}:{0m}:{0s}Z")
 
@@ -37,7 +79,7 @@ defmodule FileStorageApi.FileTest do
     start_time = Timex.now()
     expire_time = Timex.add(Timex.now(), Timex.Duration.from_hours(1))
 
-    expect(FileStorageApi.API.Mock.File, :public_url, fn container_name, filename, start_time, expire_time ->
+    expect(FileMock, :public_url, fn container_name, filename, start_time, expire_time ->
       start_time_str = Timex.format!(start_time, "{YYYY}-{0M}-{0D}T{0h24}:{0m}:{0s}Z")
       expire_time_str = Timex.format!(expire_time, "{YYYY}-{0M}-{0D}T{0h24}:{0m}:{0s}Z")
 


### PR DESCRIPTION
In case it doesn't exist yet.
Can be turned off optionally.

It will only try it once.