### PR TITLE
Feat/multiple account per storage engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ config :file_storage_api, :storage_api, engine: Azure
 S3 configuration (options from ex_aws_s3 library)
 ```elixir
 config :file_storage_api, :s3_config,
-host: "127.0.0.1",
-scheme: "http://",
-port: 9000,
-access_key_id: "admin",
-secret_access_key: "password",
-path_style: true
+  host: "127.0.0.1",
+  scheme: "http://",
+  port: 9000,
+  access_key_id: "admin",
+  secret_access_key: "password",
+  path_style: true
 ```
 
 For test S3 can also be mocked by
@@ -54,3 +54,39 @@ config :file_storage_api, :azure_blob,
 ```
 
 It will need the package `file` in linux to be able to read mime types and work.
+
+## Multiple storage accounts
+
+It can be necessary to connect to multiple S3- or Azure-accounts. This can be done by adding multiple connections, each with its own engine. To facilitate testing, it is possible to change the engine per connection.
+> :warning: A connection-name **must** end with `_conn`.
+
+---
+
+#### Example
+
+Make a custom-connection, with a S3-engine in development, and a Azure-engine in production.
+
+File: `config/dev.exs`:
+```elixir
+config :file_storage_api, :custom_conn, engine: :s3
+
+config :file_storage_api, :custom_s3_config,
+  host: "127.0.0.1",
+  scheme: "http://",
+  port: 9000,
+  access_key_id: "custom-admin",
+  secret_access_key: "custom-password",
+  path_style: true
+```
+
+File: `config/prod.exs`:
+```elixir
+config :file_storage_api, :custom_conn, engine: :azure
+
+config :file_storage_api, :custom_azure_blob,
+  account_key: "custom-password",
+  account_name: "custom-user",
+  environment_suffix: "core.windows.net",
+  host: ,
+  development: "true" || "false"
+```

--- a/lib/api/azure/base.ex
+++ b/lib/api/azure/base.ex
@@ -4,8 +4,15 @@ defmodule FileStorageApi.API.Azure.Base do
   alias ExMicrosoftAzureStorage.Storage
   alias ExMicrosoftAzureStorage.Storage.Container
 
-  def storage do
-    azure_blob = Application.get_env(:file_storage_api, :azure_blob)
+  def storage(connection_name) do
+    azure_blob =
+      case connection_name do
+        :default ->
+          Application.get_env(:file_storage_api, :azure_blob)
+
+        name ->
+          Application.get_env(:file_storage_api, String.to_existing_atom("#{name}_azure_blob"))
+      end
 
     if Keyword.fetch!(azure_blob, :development) do
       Storage.development_factory(Keyword.get(azure_blob, :host, "127.0.0.1"))
@@ -18,8 +25,8 @@ defmodule FileStorageApi.API.Azure.Base do
     end
   end
 
-  def container(container_name) do
-    Container.new(storage(), container_name)
+  def container(container_name, connection_name) do
+    Container.new(storage(connection_name), container_name)
   end
 
   @spec convert_options(FileStorageApi.Container.options()) :: [

--- a/lib/api/azure/container.ex
+++ b/lib/api/azure/container.ex
@@ -3,12 +3,14 @@ defmodule FileStorageApi.API.Azure.Container do
   @behaviour FileStorageApi.Container
 
   import FileStorageApi.API.Azure.Base
+
   alias ExMicrosoftAzureStorage.Storage.Container, as: AzureContainer
-  alias FileStorageApi.{Container, File}
+  alias FileStorageApi.Container
+  alias FileStorageApi.File
 
   @impl true
-  def create(container_name, options \\ %{}) do
-    container = container(container_name)
+  def create(container_name, connection_name, options \\ %{}) do
+    container = container(container_name, connection_name)
 
     case AzureContainer.create_container(container) do
       {:ok, result} ->
@@ -24,8 +26,8 @@ defmodule FileStorageApi.API.Azure.Container do
   end
 
   @impl true
-  def list_files(container_name, options) do
-    case AzureContainer.list_blobs(container(container_name), convert_options(options)) do
+  def list_files(container_name, connection_name, options) do
+    case AzureContainer.list_blobs(container(container_name, connection_name), convert_options(options)) do
       {:ok, %{blobs: files, max_results: max_results, next_marker: next_marker, date: date}} ->
         {:ok,
          %Container{

--- a/lib/api/s3/container.ex
+++ b/lib/api/s3/container.ex
@@ -17,31 +17,18 @@ defmodule FileStorageApi.API.S3.Container do
 
     case result do
       {:ok, result} ->
-        public =
-          if Map.has_key?(options, :public) do
-            options[:public]
-          else
-            false
-          end
+        public = read_from_map(options, :public, false)
+        cors_policy = read_from_map(options, :cors_policy, false)
 
-        cors_policy =
-          if Map.has_key?(options, :cors_policy) do
-            options[:cors_policy]
-          else
-            false
-          end
-
-        if public do
+        public &&
           container_name
           |> put_public_policy()
           |> request(connection_name)
-        end
 
-        if is_list(cors_policy) || cors_policy == true do
+        (is_list(cors_policy) || cors_policy == true) &&
           container_name
           |> put_cors(cors_policy)
           |> request(connection_name)
-        end
 
         {:ok, result}
 
@@ -111,5 +98,14 @@ defmodule FileStorageApi.API.S3.Container do
 
     bucket
     |> S3.put_bucket_cors(cors)
+  end
+
+  @spec read_from_map(map, atom, any) :: any
+  defp read_from_map(options, key, fallback_value) do
+    if Map.has_key?(options, key) do
+      options[key]
+    else
+      fallback_value
+    end
   end
 end

--- a/lib/api/s3/container.ex
+++ b/lib/api/s3/container.ex
@@ -3,20 +3,46 @@ defmodule FileStorageApi.API.S3.Container do
   @behaviour FileStorageApi.Container
 
   import FileStorageApi.API.S3.Base
+
   alias ExAws.S3
-  alias FileStorageApi.{Container, File}
+  alias FileStorageApi.Container
+  alias FileStorageApi.File
 
   @impl true
-  def create(container_name, options \\ %{}) do
+  def create(container_name, connection_name, options \\ %{}) do
     result =
       container_name
       |> S3.put_bucket(region())
-      |> request()
+      |> request(connection_name)
 
     case result do
       {:ok, result} ->
-        put_public_policy(container_name, options)
-        put_cors(container_name, options)
+        public =
+          if Map.has_key?(options, :public) do
+            options[:public]
+          else
+            false
+          end
+
+        cors_policy =
+          if Map.has_key?(options, :cors_policy) do
+            options[:cors_policy]
+          else
+            false
+          end
+
+        if public do
+          container_name
+          |> put_public_policy()
+          |> request(connection_name)
+        end
+
+        if is_list(cors_policy) || cors_policy == true do
+          container_name
+          |> put_cors(cors_policy)
+          |> request(connection_name)
+        end
+
         {:ok, result}
 
       error ->
@@ -25,10 +51,10 @@ defmodule FileStorageApi.API.S3.Container do
   end
 
   @impl true
-  def list_files(container_name, options) do
+  def list_files(container_name, connection_name, options) do
     container_name
     |> S3.list_objects(convert_options(options))
-    |> request()
+    |> request(connection_name)
     |> case do
       {:ok, %{body: %{contents: files, max_keys: max_results, next_marker: next_marker}}} ->
         {:ok,
@@ -43,14 +69,11 @@ defmodule FileStorageApi.API.S3.Container do
     end
   end
 
-  @spec put_public_policy(String.t(), map) :: :ok | {:ok, term} | {:error, term}
-  defp put_public_policy(bucket_name, %{public: true}) do
+  @spec put_public_policy(String.t()) :: ExAws.Operation.t()
+  defp put_public_policy(bucket_name) do
     bucket_name
     |> S3.put_bucket_policy(policy(bucket_name))
-    |> request()
   end
-
-  defp put_public_policy(_, _), do: :ok
 
   defp policy(bucket_name) do
     Jason.encode!(%{
@@ -69,12 +92,17 @@ defmodule FileStorageApi.API.S3.Container do
     })
   end
 
-  defp put_cors(bucket, %{cors_policy: cors_policy}) when is_list(cors_policy) or cors_policy == true do
+  defp put_cors(bucket, cors_policy) do
     cors =
       case cors_policy do
         true ->
           [
-            %{allowed_methods: ["GET"], allowed_origins: ["*"], allowed_headers: ["*"], max_age_seconds: 3000}
+            %{
+              allowed_methods: ["GET"],
+              allowed_origins: ["*"],
+              allowed_headers: ["*"],
+              max_age_seconds: 3000
+            }
           ]
 
         cors_rules ->
@@ -83,8 +111,5 @@ defmodule FileStorageApi.API.S3.Container do
 
     bucket
     |> S3.put_bucket_cors(cors)
-    |> request()
   end
-
-  defp put_cors(bucket, _), do: bucket
 end

--- a/lib/api/s3/container.ex
+++ b/lib/api/s3/container.ex
@@ -3,6 +3,7 @@ defmodule FileStorageApi.API.S3.Container do
   @behaviour FileStorageApi.Container
 
   import FileStorageApi.API.S3.Base
+  import FileStorageApi.Base
 
   alias ExAws.S3
   alias FileStorageApi.Container
@@ -98,14 +99,5 @@ defmodule FileStorageApi.API.S3.Container do
 
     bucket
     |> S3.put_bucket_cors(cors)
-  end
-
-  @spec read_from_map(map, atom, any) :: any
-  defp read_from_map(options, key, fallback_value) do
-    if Map.has_key?(options, key) do
-      options[key]
-    else
-      fallback_value
-    end
   end
 end

--- a/lib/api/s3/file.ex
+++ b/lib/api/s3/file.ex
@@ -1,17 +1,20 @@
 defmodule FileStorageApi.API.S3.File do
   @moduledoc false
-  @behaviour FileStorageApi.File
+
   import FileStorageApi.API.S3.Base
+
+  @behaviour FileStorageApi.File
+
   alias ExAws.S3
 
   @impl true
-  def upload(container_name, filename, blob_name) do
+  def upload(container_name, connection_name, filename, blob_name) do
     [{_, file_mime_type}] = filename |> FileInfo.get_info() |> Map.to_list()
     object = blob_name || Path.basename(filename)
 
     container_name
     |> S3.put_object(object, File.read!(filename), content_type: to_string(file_mime_type))
-    |> request()
+    |> request(connection_name)
     |> case do
       {:ok, %{status_code: 200}} ->
         {:ok, object}
@@ -22,20 +25,20 @@ defmodule FileStorageApi.API.S3.File do
   end
 
   @impl true
-  def delete(bucket, filename) do
+  def delete(bucket, filename, connection_name) do
     bucket
     |> S3.delete_object(Path.basename(filename))
-    |> request()
+    |> request(connection_name)
   end
 
   @impl true
-  def public_url(container_name, "/" <> file_path, start_time, expire_time),
-    do: public_url(container_name, file_path, start_time, expire_time)
+  def public_url(container_name, "/" <> file_path, start_time, expire_time, connection_name),
+    do: public_url(container_name, file_path, start_time, expire_time, connection_name)
 
-  def public_url(container_name, file_path, start_time, expire_time) do
+  def public_url(container_name, file_path, start_time, expire_time, connection_name) do
     expires_in = Timex.Comparable.diff(expire_time, start_time, :seconds)
 
-    S3.presigned_url(config(), :get, container_name, file_path, expires_in: expires_in)
+    S3.presigned_url(config(connection_name), :get, container_name, file_path, expires_in: expires_in)
   end
 
   @impl true

--- a/lib/base.ex
+++ b/lib/base.ex
@@ -1,12 +1,26 @@
 defmodule FileStorageApi.Base do
   @moduledoc false
-  def api_module(module) when module in [Container, File] do
-    Module.concat([FileStorageApi.API, storage_engine(), module])
-  end
 
-  defp storage_engine do
+  @spec storage_engine(atom) :: :s3 | :azure | :mock
+  def storage_engine(:default) do
     :file_storage_api
     |> Application.get_env(:storage_api)
     |> Keyword.get(:engine)
+    |> convert_storage_setting()
   end
+
+  def storage_engine(container_name) do
+    engine_key = String.to_existing_atom(container_name <> "_conn")
+
+    engine_key
+    |> Application.get_env(:storage_api)
+    |> Keyword.get(:engine)
+    |> convert_storage_setting()
+  end
+
+  defp convert_storage_setting("s3"), do: :s3
+  defp convert_storage_setting("S3"), do: :s3
+  defp convert_storage_setting(S3), do: :s3
+  defp convert_storage_setting(Mock), do: :mock
+  defp convert_storage_setting(_), do: :azure
 end

--- a/lib/base.ex
+++ b/lib/base.ex
@@ -9,18 +9,19 @@ defmodule FileStorageApi.Base do
     |> convert_storage_setting()
   end
 
-  def storage_engine(container_name) do
-    engine_key = String.to_existing_atom(container_name <> "_conn")
+  def storage_engine(connection_name) do
+    engine_key = String.to_existing_atom("#{connection_name}_conn")
 
-    engine_key
-    |> Application.get_env(:storage_api)
+    :file_storage_api
+    |> Application.get_env(engine_key)
     |> Keyword.get(:engine)
     |> convert_storage_setting()
   end
 
-  defp convert_storage_setting("s3"), do: :s3
-  defp convert_storage_setting("S3"), do: :s3
-  defp convert_storage_setting(S3), do: :s3
+  defp convert_storage_setting(engine) when engine in [:s3, "s3", "S3"] do
+    :s3
+  end
+
   defp convert_storage_setting(Mock), do: :mock
   defp convert_storage_setting(_), do: :azure
 end

--- a/lib/base.ex
+++ b/lib/base.ex
@@ -1,27 +1,40 @@
 defmodule FileStorageApi.Base do
   @moduledoc false
 
-  @spec storage_engine(atom) :: :s3 | :azure | :mock
-  def storage_engine(:default) do
+  def api_module(connection_name, module) when module in [Container, File] do
+    Module.concat([FileStorageApi.API, storage_engine(connection_name), module])
+  end
+
+  @spec read_from_map(map, atom, any) :: any
+  def read_from_map(options, key, fallback_value) do
+    if Map.has_key?(options, key) do
+      options[key]
+    else
+      fallback_value
+    end
+  end
+
+  @spec storage_engine(atom) :: S3 | Azure | Mock
+  defp storage_engine(:default) do
     :file_storage_api
     |> Application.get_env(:storage_api)
     |> Keyword.get(:engine)
-    |> convert_storage_setting()
+    |> convert_to_module()
   end
 
-  def storage_engine(connection_name) do
+  defp storage_engine(connection_name) do
     engine_key = String.to_existing_atom("#{connection_name}_conn")
 
     :file_storage_api
     |> Application.get_env(engine_key)
     |> Keyword.get(:engine)
-    |> convert_storage_setting()
+    |> convert_to_module()
   end
 
-  defp convert_storage_setting(engine) when engine in [:s3, "s3", "S3"] do
-    :s3
+  defp convert_to_module(engine) when engine in [:s3, "s3", "S3"] do
+    S3
   end
 
-  defp convert_storage_setting(Mock), do: :mock
-  defp convert_storage_setting(_), do: :azure
+  defp convert_to_module(Mock), do: Mock
+  defp convert_to_module(_), do: Azure
 end

--- a/test/api/azure/base_test.exs
+++ b/test/api/azure/base_test.exs
@@ -19,7 +19,7 @@ defmodule FileStorageApi.API.Azure.BaseTest do
              account_name: "account_name",
              account_key: Keyword.fetch!(azure_blob, :account_key),
              endpoint_suffix: "env_suffix"
-           } == Base.storage()
+           } == Base.storage(:default)
   end
 
   test "fetching correct storage config as development" do
@@ -37,14 +37,14 @@ defmodule FileStorageApi.API.Azure.BaseTest do
              host: "127.0.0.1",
              is_development_factory: true,
              default_endpoints_protocol: "http"
-           } == Base.storage()
+           } == Base.storage(:default)
   end
 
   test "able to create a container context" do
     assert %Container{
              container_name: "block-store-container",
-             storage_context: Base.storage()
-           } == Base.container("block-store-container")
+             storage_context: Base.storage(:default)
+           } == Base.container("block-store-container", :default)
   end
 
   test "convert option key name to be compatible with library" do

--- a/test/api/azure/file_test.exs
+++ b/test/api/azure/file_test.exs
@@ -13,7 +13,8 @@ defmodule FileStorageApi.API.Azure.FileTest do
         "block-store-container",
         "test.png",
         Timex.now(),
-        Timex.add(Timex.now(), Timex.Duration.from_days(1))
+        Timex.add(Timex.now(), Timex.Duration.from_days(1)),
+        :default
       )
 
     uri = URI.parse(url)
@@ -24,7 +25,7 @@ defmodule FileStorageApi.API.Azure.FileTest do
   test "timestamps should be correctly set in url" do
     start_time = Timex.now()
     expire_time = Timex.add(Timex.now(), Timex.Duration.from_hours(1))
-    {:ok, url} = File.public_url("block-store-container", "test.png", start_time, expire_time)
+    {:ok, url} = File.public_url("block-store-container", "test.png", start_time, expire_time, :default)
     uri = URI.parse(url)
 
     start_time_str = Timex.format!(start_time, "{YYYY}-{0M}-{0D}T{0h24}:{0m}:{0s}Z")

--- a/test/api/container_test.exs
+++ b/test/api/container_test.exs
@@ -17,7 +17,7 @@ defmodule FileStorageApi.ContainerTest do
   end
 
   test "listing files" do
-    expect(MockContainer, :list_files, fn container_name, _options ->
+    expect(MockContainer, :list_files, fn container_name, :default, _options ->
       assert container_name == "test-container"
 
       {:ok,
@@ -29,12 +29,13 @@ defmodule FileStorageApi.ContainerTest do
        }}
     end)
 
-    assert [%File{name: "test.jpg", properties: %{}}] == Enum.map(Container.list_files("test-container", []), & &1)
+    assert [%File{name: "test.jpg", properties: %{}}] ==
+             Enum.map(Container.list_files("test-container", []), & &1)
   end
 
   test "be able to list files on multiple pages" do
     expect(MockContainer, :list_files, 2, fn
-      container_name, [marker: "next_marker"] ->
+      container_name, :default, [marker: "next_marker"] ->
         assert container_name == "test-container"
 
         {:ok,
@@ -48,7 +49,7 @@ defmodule FileStorageApi.ContainerTest do
            next_marker: ""
          }}
 
-      container_name, _options ->
+      container_name, :default, _options ->
         assert container_name == "test-container"
 
         {:ok,
@@ -73,7 +74,7 @@ defmodule FileStorageApi.ContainerTest do
   end
 
   test "able to create the container" do
-    expect(MockContainer, :create, fn "block-store-container", %{} ->
+    expect(MockContainer, :create, fn "block-store-container", :default, %{} ->
       {:ok, %{}}
     end)
 

--- a/test/api/file_test.exs
+++ b/test/api/file_test.exs
@@ -14,7 +14,7 @@ defmodule FileStorageApi.FileTest do
   end
 
   test "able to upload a file" do
-    expect(FileMock, :upload, fn "block-store-container", "testfile", _blob_name ->
+    expect(FileMock, :upload, fn "block-store-container", :default, "testfile", _blob_name ->
       {:ok, %{}}
     end)
 
@@ -23,24 +23,25 @@ defmodule FileStorageApi.FileTest do
 
   test "not creating a container if not forcing on a failed upload" do
     FileMock
-    |> expect(:upload, 1, fn "block-store-container", "testfile", _blob_name ->
+    |> expect(:upload, 1, fn "block-store-container", :default, "testfile", _blob_name ->
       {:error, "Some Error"}
     end)
 
-    assert {:file_upload_error, "Some Error"} == File.upload("block-store-container", "testfile", "testfile", force_container: false)
+    assert {:file_upload_error, "Some Error"} ==
+             File.upload("block-store-container", "testfile", "testfile", force_container: false)
   end
 
   test "creating a container once, if file upload fails because of it" do
     FileMock
-    |> expect(:upload, 1, fn "block-store-container", "testfile", _blob_name ->
+    |> expect(:upload, 1, fn "block-store-container", :default, "testfile", _blob_name ->
       {:error, :container_not_found}
     end)
-    |> expect(:upload, 1, fn "block-store-container", "testfile", _blob_name ->
+    |> expect(:upload, 1, fn "block-store-container", :default, "testfile", _blob_name ->
       {:ok, "file uploaded!"}
     end)
 
     ContainerMock
-    |> expect(:create, 1, fn "block-store-container", _ ->
+    |> expect(:create, 1, fn "block-store-container", :default, _ ->
       {:ok, %{}}
     end)
 
@@ -49,12 +50,12 @@ defmodule FileStorageApi.FileTest do
 
   test "returning the error if creating container didn't help" do
     FileMock
-    |> expect(:upload, 2, fn "block-store-container", "testfile", _blob_name ->
+    |> expect(:upload, 2, fn "block-store-container", :default, "testfile", _blob_name ->
       {:error, :container_not_found}
     end)
 
     ContainerMock
-    |> expect(:create, 1, fn "block-store-container", _ ->
+    |> expect(:create, 1, fn "block-store-container", :default, _ ->
       {:ok, %{}}
     end)
 
@@ -62,7 +63,7 @@ defmodule FileStorageApi.FileTest do
   end
 
   test "able to request public url without setting expire" do
-    expect(FileMock, :public_url, fn container_name, filename, start_time, expire_time ->
+    expect(FileMock, :public_url, fn container_name, filename, start_time, expire_time, :default ->
       start_time_str = Timex.format!(start_time, "{YYYY}-{0M}-{0D}T{0h24}:{0m}:{0s}Z")
       expire_time_str = Timex.format!(expire_time, "{YYYY}-{0M}-{0D}T{0h24}:{0m}:{0s}Z")
 
@@ -79,7 +80,7 @@ defmodule FileStorageApi.FileTest do
     start_time = Timex.now()
     expire_time = Timex.add(Timex.now(), Timex.Duration.from_hours(1))
 
-    expect(FileMock, :public_url, fn container_name, filename, start_time, expire_time ->
+    expect(FileMock, :public_url, fn container_name, filename, start_time, expire_time, :default ->
       start_time_str = Timex.format!(start_time, "{YYYY}-{0M}-{0D}T{0h24}:{0m}:{0s}Z")
       expire_time_str = Timex.format!(expire_time, "{YYYY}-{0M}-{0D}T{0h24}:{0m}:{0s}Z")
 

--- a/test/api/s3/container_test.exs
+++ b/test/api/s3/container_test.exs
@@ -17,7 +17,7 @@ defmodule FileStorageApi.API.S3.ContainerTest do
       {:ok, %{}}
     end)
 
-    assert {:ok, %{}} == Container.create("block-store-container", %{})
+    assert {:ok, %{}} == Container.create("block-store-container", :default, %{})
   end
 
   test "able to set cors with create bucket operation" do
@@ -36,7 +36,7 @@ defmodule FileStorageApi.API.S3.ContainerTest do
         {:ok, %{}}
     end)
 
-    assert {:ok, %{}} == Container.create("block-store-container", %{cors_policy: true})
+    assert {:ok, %{}} == Container.create("block-store-container", :default, %{cors_policy: true})
   end
 
   test "able to set public policy with create bucket operation" do
@@ -55,7 +55,7 @@ defmodule FileStorageApi.API.S3.ContainerTest do
         {:ok, %{}}
     end)
 
-    assert {:ok, %{}} == Container.create("block-store-container", %{public: true})
+    assert {:ok, %{}} == Container.create("block-store-container", :default, %{public: true})
   end
 
   test "be able to list files and correctly convert them" do
@@ -73,7 +73,7 @@ defmodule FileStorageApi.API.S3.ContainerTest do
               max_results: 50,
               name: nil,
               next_marker: ""
-            }} == Container.list_files("block-store-container", [])
+            }} == Container.list_files("block-store-container", :default, [])
   end
 
   test "errors should be returned" do
@@ -82,6 +82,6 @@ defmodule FileStorageApi.API.S3.ContainerTest do
       {:error, %{status_code: 400}}
     end)
 
-    assert {:error, %{}} = Container.list_files("block-store-container", [])
+    assert {:error, %{}} = Container.list_files("block-store-container", :default, [])
   end
 end

--- a/test/api/s3/file_test.exs
+++ b/test/api/s3/file_test.exs
@@ -17,7 +17,8 @@ defmodule FileStorageApi.API.S3.FileTest do
         "block-store-container",
         "test.png",
         Timex.now(),
-        Timex.add(Timex.now(), Timex.Duration.from_days(1))
+        Timex.add(Timex.now(), Timex.Duration.from_days(1)),
+        :default
       )
 
     uri = URI.parse(url)
@@ -31,7 +32,8 @@ defmodule FileStorageApi.API.S3.FileTest do
         "block-store-container",
         "/test.png",
         Timex.now(),
-        Timex.add(Timex.now(), Timex.Duration.from_days(1))
+        Timex.add(Timex.now(), Timex.Duration.from_days(1)),
+        :default
       )
 
     uri = URI.parse(url)
@@ -42,7 +44,7 @@ defmodule FileStorageApi.API.S3.FileTest do
   test "timestamps should be correctly set in url" do
     start_time = Timex.now()
     expire_time = Timex.add(Timex.now(), Timex.Duration.from_hours(1))
-    {:ok, url} = File.public_url("block-store-container", "test.png", start_time, expire_time)
+    {:ok, url} = File.public_url("block-store-container", "test.png", start_time, expire_time, :default)
     uri = URI.parse(url)
 
     %{"X-Amz-Expires" => "3600"} = URI.decode_query(uri.query)
@@ -56,7 +58,7 @@ defmodule FileStorageApi.API.S3.FileTest do
       {:ok, %{}}
     end)
 
-    assert {:ok, %{}} == File.delete("block-store-container", path)
+    assert {:ok, %{}} == File.delete("block-store-container", path, :default)
   end
 
   test "upload a file with mime type" do
@@ -67,7 +69,7 @@ defmodule FileStorageApi.API.S3.FileTest do
       {:ok, %{status_code: 200}}
     end)
 
-    assert {:ok, Path.basename(file_path)} == File.upload("block-store-container", file_path, nil)
+    assert {:ok, Path.basename(file_path)} == File.upload("block-store-container", :default, file_path, nil)
   end
 
   test "failing upload should return error tuple" do
@@ -78,11 +80,14 @@ defmodule FileStorageApi.API.S3.FileTest do
       {:error, %{status_code: 400}}
     end)
 
-    assert {:error, %{}} = File.upload("block-store-container", file_path, nil)
+    assert {:error, %{}} = File.upload("block-store-container", :default, file_path, nil)
   end
 
   test "should be able to correctly convert modified at" do
-    file = %FileStorageApi.File{name: "test.png", properties: %{key: "test.png", other: "waat", last_modified: "2021-08-19T15:17:22.775Z"}}
+    file = %FileStorageApi.File{
+      name: "test.png",
+      properties: %{key: "test.png", other: "waat", last_modified: "2021-08-19T15:17:22.775Z"}
+    }
 
     assert {:ok, ~U[2021-08-19 15:17:22.775Z]} == File.last_modified(file)
   end


### PR DESCRIPTION
Support multiple connection, each with an configurable engine.

This will make it possible to write to multiple Azure-accounts. Which
can be configured to use S3 on development-environments.

For backwards-compatibility, connection `default` is used when no
connection-name is given. This connection will use the existing
configuration.
