### PR TITLE
Use mimetype to detect mime-types, when installed

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -25,7 +25,11 @@ jobs:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
         restore-keys: ${{ runner.os }}-mix-
-    - name: Install dependencies
+    - name: Install OS dependencies
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: apt install libfile-mimeinfo-perl shared-mime-info
+    - name: Install Elixir dependencies
       run: mix deps.get
     - name: Run tests
       run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install OS dependencies
       env:
         DEBIAN_FRONTEND: noninteractive
-      run: apt install libfile-mimeinfo-perl shared-mime-info
+      run: sudo apt install libfile-mimeinfo-perl shared-mime-info
     - name: Install Elixir dependencies
       run: mix deps.get
     - name: Run tests

--- a/lib/api/s3/file.ex
+++ b/lib/api/s3/file.ex
@@ -9,7 +9,7 @@ defmodule FileStorageApi.API.S3.File do
 
   @impl true
   def upload(container_name, connection_name, filename, blob_name) do
-    [{_, file_mime_type}] = filename |> FileInfo.get_info() |> Map.to_list()
+    file_mime_type = mime_type(filename)
     object = blob_name || Path.basename(filename)
 
     container_name
@@ -29,6 +29,23 @@ defmodule FileStorageApi.API.S3.File do
     bucket
     |> S3.delete_object(Path.basename(filename))
     |> request(connection_name)
+  end
+
+  defp mime_type(filename) do
+    case System.shell("which mimetype") do
+      {_location, 0} ->
+        {result, 0} = System.shell("mimetype #{filename}")
+
+        result
+        |> String.trim()
+        |> String.split(" ")
+        |> Enum.reverse()
+        |> hd()
+
+      {_empty, 1} ->
+        [{_, file_mime_type}] = filename |> FileInfo.get_info() |> Map.to_list()
+        file_mime_type
+    end
   end
 
   @impl true

--- a/test/api/s3/file_test.exs
+++ b/test/api/s3/file_test.exs
@@ -72,6 +72,17 @@ defmodule FileStorageApi.API.S3.FileTest do
     assert {:ok, Path.basename(file_path)} == File.upload("block-store-container", :default, file_path, nil)
   end
 
+  test "upload a file with mime type application/javascript (requires mimetype to be installed)" do
+    file_path = "./test/support/hello.js"
+
+    expect(AwsMock, :request, fn operation, _config ->
+      assert %{http_method: :put, path: "hello.js", headers: %{"content-type" => "application/javascript"}} = operation
+      {:ok, %{status_code: 200}}
+    end)
+
+    assert {:ok, Path.basename(file_path)} == File.upload("block-store-container", :default, file_path, nil)
+  end
+
   test "failing upload should return error tuple" do
     file_path = "./test/support/test_icon.png"
 

--- a/test/support/hello.js
+++ b/test/support/hello.js
@@ -1,0 +1,1 @@
+alert("Hello, world")


### PR DESCRIPTION
This program uses the mime-database to detect mime-types from plain-text files via its extention, like javascript and markdown