### PR TITLE
Feat/implement external host config dt 4108

### DIFF
--- a/lib/api/s3/base.ex
+++ b/lib/api/s3/base.ex
@@ -25,6 +25,7 @@ defmodule FileStorageApi.API.S3.Base do
       secret_access_key: Access.get(s3_config, :secret_key),
       s3_auth_version: Access.get(s3_config, :s3_auth_version, 4),
       host: Access.get(s3_config, :host),
+      external_host: Access.get(s3_config, :external_host),
       scheme: Access.get(s3_config, :scheme),
       port: Access.get(s3_config, :port),
       http_opts: http_opts()
@@ -70,11 +71,14 @@ defmodule FileStorageApi.API.S3.Base do
     storage_api = Application.get_env(:file_storage_api, :storage_api, [])
 
     case Keyword.get(storage_api, :custom_ca_cert) do
-      cert when is_binary(cert) and byte_size(cert) > 0 -> [
-        {:ssl, [cacertfile: cert]},
-        {:ssl_options, [cacertfile: cert, verify: :verify_peer]}
-      ]
-      _ -> []
+      cert when is_binary(cert) and byte_size(cert) > 0 ->
+        [
+          {:ssl, [cacertfile: cert]},
+          {:ssl_options, [cacertfile: cert, verify: :verify_peer]}
+        ]
+
+      _ ->
+        []
     end
   end
 end

--- a/lib/api/s3/file.ex
+++ b/lib/api/s3/file.ex
@@ -35,34 +35,44 @@ defmodule FileStorageApi.API.S3.File do
   def public_url(container_name, "/" <> file_path, opts), do: public_url(container_name, file_path, opts)
 
   def public_url(container_name, file_path, opts) do
-    is_public = Keyword.get(opts, :public, false)
+    public? = Keyword.get(opts, :public, false)
     connection = Keyword.get(opts, :connection)
     start_time = Keyword.get(opts, :start_time)
     expire_time = Keyword.get(opts, :expire_time)
 
     expires_in = Timex.Comparable.diff(expire_time, start_time, :seconds)
+    storage_config = config(connection)
 
-    s3_signed =
-      S3.presigned_url(Config.new(:s3, config(connection)), :get, container_name, file_path, expires_in: expires_in)
+    s3_signed = S3.presigned_url(Config.new(:s3, storage_config), :get, container_name, file_path, expires_in: expires_in)
 
     case s3_signed do
-      {:ok, url} ->
-        if is_public do
-          public_url =
-            url
-            |> URI.parse()
-            |> Map.put(:query, nil)
-            |> URI.to_string()
-
-          {:ok, public_url}
-        else
-          {:ok, url}
-        end
-
-      error ->
-        error
+      {:ok, url} -> {:ok, transform_url(url, public?, storage_config)}
+      error -> error
     end
   end
+
+  @spec transform_url(binary, boolean, Keyword.t()) :: binary
+  defp transform_url(signed_url, public?, storage_config) do
+    url
+    |> URI.parse()
+    |> replace_host(storage_config[:external_host])
+    |> remove_query_params(public?)
+    |> URI.to_string()
+  end
+
+  @spec replace_host(URI.t(), binary | nil) :: URI.t()
+  defp replace_host(url, nil), do: url
+
+  defp replace_host(url, external_host) when is_binary(external_host) do
+    Map.put(parsed_url, :host, external_host)
+  end
+
+  @spec remove_query_params(URI.t(), boolean) :: URI.t()
+  defp remove_query_params(url, true) do
+    Map.put(parsed_url, :query, nil)
+  end
+
+  defp remove_query_params(url, _), do: url
 
   @impl true
   def last_modified(%FileStorageApi.File{properties: %{last_modified: timestamp}}) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule FileStorageApi.MixProject do
   def project do
     [
       app: :file_storage_api,
-      version: "2.1.4",
+      version: "2.2.0",
       elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [warnings_as_errors: Mix.env() != :test],


### PR DESCRIPTION
Add the ability to set an external host, the signature will still be calculated based on the host, but it will replace it with external host when returning a public url